### PR TITLE
Added support for manually adding external sites

### DIFF
--- a/multisite-admin-bar-switcher.php
+++ b/multisite-admin-bar-switcher.php
@@ -298,7 +298,7 @@ function mabs_display_blogs_for_user( $user )
 			'parent' => $site_parent,
 			'id' => 'mabs_'.$letter.$i,
 			'title' => apply_filters('mabs_blog_name', $blog->blogname, $blog),
-			'href' => $blog->external_site == 'network' ? $admin_url . '/network/' : $admin_url,
+			'href' => $blog->external_site == 'network' ? $admin_url . 'network/' : $admin_url,
 			'meta' => array(
 				'class' => 'mabs_blog',
 				'target' => $blog->external_site ? '_blank' : '',

--- a/multisite-admin-bar-switcher.php
+++ b/multisite-admin-bar-switcher.php
@@ -127,7 +127,9 @@ add_action('admin_bar_menu', function() {
 			'href' => $url,
 		));
 		mabs_display_blog_pages($current_user, 'network', $url);
-	}	
+	}
+
+	do_action ('mabs_top_level_menus');
 
 	// Add users' blogs
 	mabs_display_blogs_for_user( $current_user );
@@ -199,7 +201,7 @@ function mabs_site_count_below_minimum($user)
  *
  * @return void
  */
-function mabs_display_blog_pages( $user, $id, $admin_url, $external_site )
+function mabs_display_blog_pages( $user, $id, $admin_url, $blog )
 {
 	global $wp_admin_bar;
 	if ( $id == 'network' )
@@ -228,7 +230,7 @@ function mabs_display_blog_pages( $user, $id, $admin_url, $external_site )
 			'settings'      => array('url' => 'options-general.php','permission' => 'manage_options'),
 		);
 
-	$pages = apply_filters('mabs_blog_pages', $pages, $id, $user);
+	$pages = apply_filters('mabs_blog_pages', $pages, $id, $user, $blog);
 
 	foreach ( $pages as $key => $details )
 	{
@@ -239,7 +241,7 @@ function mabs_display_blog_pages( $user, $id, $admin_url, $external_site )
 				'title'=>__('Visit Site'),
 				'href'=>str_replace('wp-admin/','',$admin_url),
 				'meta' => array(
-					'target' => $external_site ? '_blank' : '',
+					'target' => $blog->external_site ? '_blank' : '',
 				),				
 			));
 		elseif ( empty($details['permission']) || user_can($user->ID, $details['permission']) )
@@ -247,9 +249,9 @@ function mabs_display_blog_pages( $user, $id, $admin_url, $external_site )
 				'parent' => 'mabs_'.$id,
 				'id' =>'mabs_'.$id.'_'.$key,
 				'title'=> isset($details['title']) ? $details['title'] : __(ucfirst($key)),
-				'href' => $admin_url.$details['url'],
+				'href' => strpos($details['url'], 'http') !== false ? $details['url'] : $admin_url.$details['url'],
 				'meta' => array(
-					'target' => $external_site ? '_blank' : '',
+					'target' => $blog->external_site ? '_blank' : '',
 				),					
 			));
 	}
@@ -304,7 +306,7 @@ function mabs_display_blogs_for_user( $user )
 		));
 
 		//Add site submenu options
-		mabs_display_blog_pages($user, $letter.$i, $admin_url, $blog->external_site);
+		mabs_display_blog_pages($user, $letter.$i, $admin_url, $blog);
 
 		$i++;
 	}


### PR DESCRIPTION
'mabs_unsorted_sites_list' filter added, and some conditionals in the main code to check if the site added to the admin bar is an external site (to add things like target="_blank" and the proper external url).

To test extending the menu to add an external site, check out this code:

```
add_filter('mabs_unsorted_sites_list', 'mb_add_additional_sites', 10, 1); 
function mb_add_additional_sites( $sites ) {
    $new_sites = array (    
        'External Multisite' => 'example.com/wp-admin/network/',
        'External Single Site' => 'example.com/wp-admin/', 
    );

    foreach ($new_sites as $new_site_name => $new_site_url) {
        $add_site->external_site = 'single';    
        $add_site->blogname = $new_site_name . ' (Single Site)';
        if ( strpos($new_site_url, 'network/') !== false ) {
            $new_site_url = str_replace('network/', '', $new_site_url);         
            $add_site->external_site = 'network';           
            $add_site->blogname = $new_site_name . ' (Multisite)';          
        }
        $add_site->adminurl = 'http://' . $new_site_url;    
        $sites[] = clone $add_site;         
    }
    return $sites;
}
```
