### PR TITLE
Retrieve More Sites

### DIFF
--- a/multisite-admin-bar-switcher.php
+++ b/multisite-admin-bar-switcher.php
@@ -3,7 +3,7 @@
     Plugin Name: Multisite Admin bar Switcher
     Plugin URI: http://www.flynsarmy.com
     Description: Replaces the built in 'My Sites' drop down with a better layed out one
-    Version: 1.2.5
+    Version: 1.2.6
     Author: Flyn San
     Author URI: http://www.flynsarmy.com/
 
@@ -420,7 +420,8 @@ function mabs_get_blogs_of_network()
     if ( !$cache )
     {
         // This method returns different info than get_blogs_of_user(). So make it the same
-        $blog_list = get_sites();
+        $args = array( 'number' => 250 ); // Change number to show more sites (WordPress default is 100)
+        $blog_list = get_sites( $args );
         $unsorted_list = array();
 
         foreach ( $blog_list as $id => $info )

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: flynsarmy
 Tags: multisite, toolbar, switcher, switch, network, admin, wpmu
 Requires at least: 3.2.1
 Tested up to: 4.6
-Stable tag: 1.2.5
+Stable tag: 1.2.6
 
 == Description ==
 
@@ -77,6 +77,9 @@ add_filter('mabs_cache_duration', function($cachetime) {
 `
 
 == Changelog ==
+
+= 1.2.6 =
+* Added setting to retrieve more sites as WordPress get_sites(); default is 100, setting is now 250
 
 = 1.2.5 =
 * wp_get_sites() deprecation fix


### PR DESCRIPTION
Added ‘number’ => 250 to get_sites(); to increase number of retrieved
sites (WordPress default is 100), also updated version number